### PR TITLE
Enable create.boxplot to print different text label on each panel

### DIFF
--- a/R/create.boxplot.R
+++ b/R/create.boxplot.R
@@ -243,11 +243,12 @@ create.boxplot <- function(
 
 			# Add text to plot
 			if (add.text) {
-
+                row = parent.frame(2)$row
+                column = parent.frame(2)$column
 				panel.text(
 					x	= text.info$x,
 					y	= text.info$y,
-					labels   = text.info$labels,
+					labels   = text.info$labels[row, column],
 					col      = text.info$col,
 					cex      = text.info$cex,
 					fontface = text.info$fontface,

--- a/R/create.boxplot.R
+++ b/R/create.boxplot.R
@@ -243,12 +243,11 @@ create.boxplot <- function(
 
 			# Add text to plot
 			if (add.text) {
-                row = parent.frame(2)$row
-                column = parent.frame(2)$column
+                which.packet = parent.frame(2)$which.packet
 				panel.text(
 					x	= text.info$x,
 					y	= text.info$y,
-					labels   = text.info$labels[row, column],
+					labels   = text.info$labels[which.packet],
 					col      = text.info$col,
 					cex      = text.info$cex,
 					fontface = text.info$fontface,

--- a/R/create.boxplot.R
+++ b/R/create.boxplot.R
@@ -243,7 +243,7 @@ create.boxplot <- function(
 
 			# Add text to plot
 			if (add.text) {
-                which.packet = parent.frame(2)$which.packet
+				which.packet = parent.frame(2)$which.packet
 				panel.text(
 					x	= text.info$x,
 					y	= text.info$y,

--- a/R/create.boxplot.R
+++ b/R/create.boxplot.R
@@ -243,7 +243,7 @@ create.boxplot <- function(
 
 			# Add text to plot
 			if (add.text) {
-				which.packet = parent.frame(2)$which.packet
+				which.packet <- parent.frame(2)$which.packet;
 				panel.text(
 					x	= text.info$x,
 					y	= text.info$y,

--- a/man/create.boxplot.Rd
+++ b/man/create.boxplot.Rd
@@ -184,7 +184,7 @@ create.boxplot(
     \item{left.padding}{A number specifying the distance to the left margin, defaults to 2}
     \item{ylab.axis.padding}{A number specifying the distance of y-axis label to the y-axis, defaults to 0},
     \item{add.text}{Allow additional text to be drawn, default is FALSE}
-    \item{text.labels}{Labels for additional text}
+    \item{text.labels}{Labels for additional text. If the formula contains group, the length of this argument should match with the number of groups.}
     \item{text.x}{The x co-ordinates where additional text should be placed}
     \item{text.y}{The y co-ordinates where additional text should be placed}
     \item{text.anchor}{Part of text that should be anchored to x/y coordinates. Defaults to 'centre'. Use 'left' or 'right' to left or right-align text.}


### PR DESCRIPTION
This is an work around to be able to set different text labels on each panel

Data: https://github.com/uclahs-cds/public-R-BoutrosLab-plotting-general/files/7003378/create.boxplot.data.txt

```R
data <- read.table(file = 'create.boxplot.data.txt', header = TRUE);
dummy.data <- data.frame(
    expression_score = NA,
    sex = 'Male',
    gene = 'DDX3X'
    );
data <- rbind(data, dummy.data);
data <- data[order(data$gene, data$sex),]

# Assemble color vector
sex.colours <- replace(data$sex, which(data$sex == 'Male'),'dodgerblue');
sex.colours <- replace(sex.colours, which(data$sex == 'Female'), 'pink');
# Plot
ymin <- min(data$expression_score, na.rm = TRUE)
ymax <- max(data$expression_score, na.rm = TRUE)
ymax <- ymax + (ymax - ymin) * 0.15
p <- create.boxplot(
    formula = expression_score ~ sex | gene,
    data = data,
    add.stripplot = TRUE,
    points.col = sex.colours,
    text.labels = c('A', 'B'),
    text.x = 1.5,
    text.y = 0,
    add.text = TRUE,
    ylimits = c(ymin, ymax)
    );
```

![image](https://user-images.githubusercontent.com/29579625/130696986-83beebf7-c962-44d0-bac9-b59e3f06d233.png)
