### PR TITLE
Refactor hardcoded "magic numbers" in legend.grob

### DIFF
--- a/R/legend.grob.R
+++ b/R/legend.grob.R
@@ -48,16 +48,19 @@ legend.grob <- function(
 		# Create a layout for the legends
 		# Each legend gets an extra row for its title
 		# There is also an extra empty row/column inserted between each of the legends to allow for nicer spacing
+		row.buffer <- 3;
+		col.buffer <- 2;
+		
 		legend.layout <- grid.layout(
-			ncol = layout[1] * 2 - 1,
-			nrow = layout[2] * 3 - 1,
+			ncol = layout[1] * col.buffer - 1,
+			nrow = layout[2] * row.buffer - 1,
 			heights = unit(
 				c(0, 0, rep(c(between.row, 0, 0), layout[2] - 1)),
-				c(rep('lines', layout[2] * 3 - 1))
+				c(rep('lines', layout[2] * row.buffer - 1))
 				),
 			widths = unit(
 				c(rep(c(0, between.col), layout[1] - 1), 0),
-				c(rep('lines', layout[1] * 2 - 1))
+				c(rep('lines', layout[1] * col.buffer - 1))
 				)
 			);
 
@@ -120,10 +123,10 @@ legend.grob <- function(
 				legend.grob.final <- packGrob(
 					frame = legend.grob.final,
 					grob = title.grob,
-					row = 3 * (legend.row - 1) + 1,
-					col = 2 * (legend.col - 1) + 1,
+					row = row.buffer * (legend.row - 1) + 1,
+					col = col.buffer * (legend.col - 1) + 1,
 					height = max(
-						legend.grob.final$framevp$layout$heights[3 * (legend.row - 1) + 1],
+						legend.grob.final$framevp$layout$heights[row.buffer * (legend.row - 1) + 1],
 						unit(title.grob.height + 0.4, 'lines')
 						),
 					force.height = TRUE,
@@ -181,11 +184,11 @@ legend.grob <- function(
 				legend.grob.final <- packGrob(
 					frame = legend.grob.final,
 					grob = color.key.grob,
-					row = 3 * (legend.row - 1) + 2,
-					col = 2 * (legend.col - 1) + 1,
+					row = row.buffer * (legend.row - 1) + 2,
+					col = col.buffer * (legend.col - 1) + 1,
 					height = max(
 					    unit(legendi[['height']], 'lines'),
-					    legend.grob.final$framevp$layout$heights[3 * (legend.row - 1) + 1]
+					    legend.grob.final$framevp$layout$heights[row.buffer * (legend.row - 1) + 1]
 					    ),
 					force.height = TRUE,
 					);
@@ -232,8 +235,8 @@ legend.grob <- function(
 				legend.grob.final <- packGrob(
 					frame = legend.grob.final,
 					grob = draw.key(key = legend.key, draw = FALSE),
-					row = 3 * (legend.row - 1) + 2,
-					col = 2 * (legend.col - 1) + 1
+					row = row.buffer * (legend.row - 1) + 2,
+					col = col.buffer * (legend.col - 1) + 1
 					);
 				}
 			}


### PR DESCRIPTION
- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added the changes included in this pull request to `NEWS` under the next release version or unreleased, and updated the date.

- [X] I have updated the version number in `metadata.yaml` and `DESCRIPTION`.

- [X] Both `R CMD build` and `R CMD check` run successfully.

Closes #8 

The values mentioned in the issue are explained in this comment (found earlier in the file).
```
# Create a layout for the legends
# Each legend gets an extra row for its title
# There is also an extra empty row/column inserted between each of the legends to allow for nicer spacing
```

Instead of creating multiple comments to explain the same value, it made more sense to change the repeated hardcoded values to variables.

## Testing Results
```
legends <- list(
	legend = list(
		colours = c('orange', 'chartreuse4', 'darkorchid4'),
		labels = c('Group 1', 'Group 2', 'Group 3'),
		title = expression(underline('Legend #1'))
		),
	# Use dots instead of rectangles
	point = list(
		colours = c('firebrick3', 'lightgrey'),
		labels = c('A label', 'A longer label'),
		# Set dot size
		cex = 1.5
		)
	)
	
legend.grob(
	legends = legends,
	border = list(col = 'blue', lwd = 2, lty = 3),
	border.padding = 1.5,
	between.row = 3
	);
```
