### PR TITLE
Test CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Test CODEOWNERS
+
+# Default owner(s)
+*	@dan-knight  @ucla-cds/software-wg


### PR DESCRIPTION
Added a test `CODEOWNERS` file with myself and the software working group. This is not a permanent setup. For example, Paul should probably be included on the open source packages for which he's listed as the maintainer on CRAN.