### PR TITLE
Resolve S3 Generic Naming Conflict

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: BoutrosLab.plotting.general
-Version: 6.1.0
+Version: 7.0.0
 Type: Package
 Title: Functions to Create Publication-Quality Plots
-Date: 2021-10-26
+Date: 2022-02-08
 Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@mednet.ucla.edu"),
              person("Christine P'ng", role = "ctb"),
              person("Jeff Green", role = "ctb"),
@@ -12,7 +12,8 @@ Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@me
              person("The R Foundation",role = "cph"),
              person("Robert Gentleman", role = "ctb"),
              person("Ross Ihaka", role = "ctb"),
-             person("Caden Bugh", role = "ctb"))
+             person("Caden Bugh", role = "ctb"),
+	     person("Dan Knight", role = "ctb"))
 Maintainer: Paul Boutros <PBoutros@mednet.ucla.edu>
 Depends: R (>= 3.5.0), lattice (>= 0.20-35), latticeExtra (>= 0.6-27), cluster (>= 2.0.0), hexbin (>= 1.27.0), grid
 Imports: gridExtra,  tools, gtable, e1071, MASS(>= 7.3-29)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -46,7 +46,7 @@ export(
 	"get.correlation.p.and.corr",
 	"get.defaults",
 	"get.line.breaks",
-	"ks.test.critical.value",
+	"critical.value.ks.test",
 	"legend.grob",
 	"pcawg.colours",
 	"scientific.notation",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+BoutrosLab.plotting.general 7.0.0 2022-02-08
+
+UPDATE
+* Renamed ks.test.critical.value() function to critical.value.ks.test()
+  to resolve naming conflict with S3 generic ks.test() from base R stats
+  package.
+
 BoutrosLab.plotting.general 6.1.0 2021-10-26
 
 UPDATE

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@ UPDATE
   to resolve naming conflict with S3 generic ks.test() from base R stats
   package.
 
+-------------------------------------------------------------------------- 
 BoutrosLab.plotting.general 6.1.0 2021-10-26
 
 UPDATE

--- a/R/create.qqplot.fit.confidence.interval.R
+++ b/R/create.qqplot.fit.confidence.interval.R
@@ -79,7 +79,7 @@ create.qqplot.fit.confidence.interval <- function(x, distribution = qnorm, conf 
 		# Note that this statistics should follow a kolmogorov distribution when the sample size is large
 
 		# the critical value from the Kolmogorov-Smirnov Test
-		critical.value <- BoutrosLab.plotting.general::ks.test.critical.value(length(sorted.sample), conf);
+		critical.value <- BoutrosLab.plotting.general::critical.value.ks.test(length(sorted.sample), conf);
 	
 		# under the null hypothesis, get the CI for the probabilities
 		# the probabilities of the fitted value under the empirical cdf

--- a/R/critical.value.ks.test.R
+++ b/R/critical.value.ks.test.R
@@ -9,7 +9,7 @@
 # If publications result from research using this SOFTWARE, we ask that the Ontario Institute for Cancer Research be acknowledged and/or
 # credit be given to OICR scientists, as scientifically appropriate.
 
-ks.test.critical.value <- function(n, conf, alternative = "two.sided") {
+critical.value.ks.test <- function(n, conf, alternative = "two.sided") {
 	
 	if(alternative == "one-sided") conf <- 1- (1-conf)*2;
 

--- a/man/critical.value.ks.test.Rd
+++ b/man/critical.value.ks.test.Rd
@@ -1,9 +1,9 @@
-\name{ks.test.critical.value}
-\alias{ks.test.critical.value}
+\name{critical.value.ks.test}
+\alias{critical.value.ks.test}
 \title{Critical Value for Kolmogorov-Smirnov Test}
 \description{Takes a sample size and a confidence level and computes the corresponding critical value basing on the kolmogorov-smirnov test}
 \usage{
-ks.test.critical.value(n, conf, alternative = "two.sided");
+critical.value.ks.test(n, conf, alternative = "two.sided");
 }
 \arguments{
   \item{n}{The sample size}
@@ -13,7 +13,7 @@ ks.test.critical.value(n, conf, alternative = "two.sided");
 \value{The corresponding critical value}
 \author{Ying Wu}
 \examples{
-ks.test.critical.value(10, 0.95);
-ks.test.critical.value(100, 0.95, alternative = "one-sided");
+critical.value.ks.test(10, 0.95);
+critical.value.ks.test(100, 0.95, alternative = "one-sided");
 }
 \keyword{htest}


### PR DESCRIPTION
- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added the changes included in this pull request to `NEWS` under the next release version or unreleased, and updated the date.

- [X] I have updated the version number in `metadata.yaml` and `DESCRIPTION`.

- [X] Both `R CMD build` and `R CMD check` run successfully.

S3 generic functions allow a function to execute differently depending on the type of object that is passed to the function. This is a feature in R that allows some OOP-ish patterns. Once an S3 generic function is defined, it can be extended by adding a class name to the end of the function name (separated by a period `.`).

There is a function in the base R `stats` package called `ks.test()`. In BPG, there is a function called `ks.test.critical.value()` (originally part of BL.statistics.general). In the most recent version of R, `ks.test` was converted to an S3 generic, causing our function to appear as an extension of this function. However, the two are unrelated in their implementation. This caused the CRAN checks to raise the following error:

```
Check: S3 generic/method consistency
Result: WARN
    ks.test:
     function(x, ...)
    ks.test.critical.value:
     function(n, conf, alternative)
    
    See section 'Generic functions and methods' in the 'Writing R
    Extensions' manual.
```

The solution is to simply rename the function to avoid the `ks.test` prefix. Resolving the naming conflict makes the checks pass. This will break some older code that might use the function, but there doesn't seem to be a way to avoid this. Fortunately, this seems like a seldom used helper function, so the effect will be minimal. 

I've included a specific reference to the name change in `NEWS`. Hopefully this is clear to users. Are there any other ideas to communicate the change?