### PR TITLE
Fix bug in polygonplot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: BoutrosLab.plotting.general
 Version: 7.0.0
 Type: Package
 Title: Functions to Create Publication-Quality Plots
-Date: 2022-02-08
+Date: 2022-02-15
 Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@mednet.ucla.edu"),
              person("Christine P'ng", role = "ctb"),
              person("Jeff Green", role = "ctb"),

--- a/NEWS
+++ b/NEWS
@@ -1,9 +1,12 @@
-BoutrosLab.plotting.general 7.0.0 2022-02-08
+BoutrosLab.plotting.general 7.0.0 2022-02-15
 
 UPDATE
 * Renamed ks.test.critical.value() function to critical.value.ks.test()
   to resolve naming conflict with S3 generic ks.test() from base R stats
   package.
+
+BUG
+* Fix issue when specifying multiple line-widths in create.polygonplot()
 
 -------------------------------------------------------------------------- 
 BoutrosLab.plotting.general 6.1.0 2021-10-26

--- a/R/create.polygonplot.R
+++ b/R/create.polygonplot.R
@@ -343,9 +343,12 @@ create.polygonplot <- function(
 					as.character(factor(x = groups, labels = median.col));
 					}
 
-				median.lty <- if (length(median.lty) == 1) { rep(median.lty, length(subscripts)); }
+				median.lty <- if (length(median.lty) == 1) { rep(median.lty, length(subscripts)); } else {
+					as.numeric(factor(x = groups, labels = median.lty));
+				}
+				
 				median.lwd <- if (length(median.lwd) == 1) { rep(median.lwd, length(subscripts)); } else {
-					as.character(factor(x = groups, labels = median.lty));
+					as.character(factor(x = groups, labels = median.lwd));
 					}
 
 				# Plot polygons


### PR DESCRIPTION
- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [GitHub standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added the changes included in this pull request to `NEWS` under the next release version or unreleased, and updated the date.

- [X] I have updated the version number in `metadata.yaml` and `DESCRIPTION`.

- [X] Both `R CMD build` and `R CMD check` run successfully.

See #13 for issue/solution description. There are slight differences between the parameter types, so I did not end up using the utility function idea - keeping the existing if/else structure instead.

## Testing Results
![example plot](https://user-images.githubusercontent.com/56950335/154148402-9fea3abb-1de4-45da-aa8b-82dda4dec5fb.png)

### Example Code

```
fill.matrix <- function(x, gene, data){
    for(i in x){
        gene[i, 1:i] <- rep(NA, i);
        gene[i, i:58] <- rep(as.numeric(data[i]), 58-i+1);
        }
    return(gene);
    }; 

get.polygon.data <- function(num){
    
    data1 <- microarray[num, 1:58];
    gene1 <- as.data.frame(matrix(nrow = 58, ncol = 58));
    gene1 <- fill.matrix(1:58, gene1, data1);
    gene1 <- t(matrix(unlist(gene1), ncol = 58, byrow = TRUE));
    polygon.data.gene1 <- data.frame(
        x = 1:58,
        max = apply(gene1, 2, function(x) {max(x, na.rm = TRUE)}),
        median = apply(gene1, 2, function(x) {median(x, na.rm = TRUE)}),
        min = apply(gene1, 2, function(x) {min(x, na.rm = TRUE)}),
        set = rownames(microarray[num,]),
        extra = apply(microarray[1:58], 2, function(x) {median(x)})
        );
    return(polygon.data.gene1)

}

polygon.data <- rbind(get.polygon.data(1),
                        get.polygon.data(2),
                        get.polygon.data(3),
                        get.polygon.data(4),
                        get.polygon.data(5),
                        get.polygon.data(6),
                        get.polygon.data(7),
                        get.polygon.data(8))

create.polygonplot(
        NA ~ x,
        data = polygon.data,
        # shape
        max = polygon.data$max,
        min = polygon.data$min,
        groups = polygon.data$set,
        # don't care about the polygon
        col = 'transparent',
        alpha = 0.1,
        lwd = 0,
        xlimits = c(0,58),
        # only care about the median
        add.median = TRUE,
        median = polygon.data$median,
        median.lty = c(1,2,3,4,1,2,3,4),
        median.col = default.colours(8),
        median.lwd = c(2,4,6,8,8,6,4,2)
    );
```