### PR TITLE
Fix C object protection issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@me
              person("Robert Gentleman", role = "ctb"),
              person("Ross Ihaka", role = "ctb"),
              person("Caden Bugh", role = "ctb"),
-	    	 person("Dan Knight", role = "ctb"))
+             person("Dan Knight", role = "ctb"))
 Maintainer: Paul Boutros <PBoutros@mednet.ucla.edu>
 Depends: R (>= 3.5.0), lattice (>= 0.20-35), latticeExtra (>= 0.6-27), cluster (>= 2.0.0), hexbin (>= 1.27.0), grid
 Imports: gridExtra,  tools, gtable, e1071, MASS(>= 7.3-29)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: BoutrosLab.plotting.general
-Version: 7.0.0
+Version: 7.0.1
 Type: Package
 Title: Functions to Create Publication-Quality Plots
-Date: 2022-02-15
+Date: 2022-03-03
 Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@mednet.ucla.edu"),
              person("Christine P'ng", role = "ctb"),
              person("Jeff Green", role = "ctb"),
@@ -13,7 +13,7 @@ Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@me
              person("Robert Gentleman", role = "ctb"),
              person("Ross Ihaka", role = "ctb"),
              person("Caden Bugh", role = "ctb"),
-	     person("Dan Knight", role = "ctb"))
+	    	 person("Dan Knight", role = "ctb"))
 Maintainer: Paul Boutros <PBoutros@mednet.ucla.edu>
 Depends: R (>= 3.5.0), lattice (>= 0.20-35), latticeExtra (>= 0.6-27), cluster (>= 2.0.0), hexbin (>= 1.27.0), grid
 Imports: gridExtra,  tools, gtable, e1071, MASS(>= 7.3-29)

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+BoutrosLab.plotting.general 7.0.1 2022-03-03
+
+BUG
+* Fix object protection issue in distance.c
+
+-------------------------------------------------------------------------- 
 BoutrosLab.plotting.general 7.0.0 2022-02-15
 
 UPDATE

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,6 +10,7 @@ Contributors:
   - Robert Gentleman
   - Ross Ihaka
   - Caden Bugh
+  - Dan Knight
 Languages:
   - R
   - C
@@ -24,4 +25,4 @@ Dependencies:
   - knitr
   - testthat
 References: https://doi.org/10.1186/s12859-019-2610-2
-Version: 6.0.1
+Version: 7.0.1

--- a/src/distance.c
+++ b/src/distance.c
@@ -322,10 +322,14 @@ SEXP Cdist(SEXP x, SEXP smethod, SEXP attrs, SEXP p)
     PROTECT(ans = allocVector(REALSXP, N));
     R_distance(REAL(x), &nr, &nc, REAL(ans), &diag, &method, &rp);
     /* tack on attributes */
-    SEXP names = getAttrib(attrs, R_NamesSymbol);
-    for (int i = 0; i < LENGTH(attrs); i++)
-	setAttrib(ans, install(translateChar(STRING_ELT(names, i))),
+    SEXP names = PROTECT(getAttrib(attrs, R_NamesSymbol));
+    PROTECT(attrs);
+    
+    for (int i = 0; i < LENGTH(attrs); i++) {
+		setAttrib(ans, install(translateChar(STRING_ELT(names, i))),
 		  VECTOR_ELT(attrs, i));
-    UNPROTECT(1);
+	}
+    
+    UNPROTECT(3);
     return ans;
 }


### PR DESCRIPTION
- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] I have added the changes included in this pull request to `NEWS` under the next release version or unreleased, and updated the date.

- [X] I have updated the version number in `metadata.yaml` and `DESCRIPTION`.

- [X] Both `R CMD build` and `R CMD check` run successfully.

CRAN's checks found these issues in `distance.c`:

```Function Cdist
  [UP] unprotected variable names while calling allocating function Rf_install BoutrosLab.plotting.general/src/distance.c:327
  [UP] unprotected variable names while calling allocating function Rf_setAttrib(V,?,?) BoutrosLab.plotting.general/src/distance.c:327
  [UP] unprotected variable names while calling allocating function Rf_translateChar BoutrosLab.plotting.general/src/distance.c:327
```

These are related to protecting/unprotecting pointers that will be used by R. Calling `PROTECT()` on `attrs` and `names`, then subsequently unprotecting them with `UNPROTECT(3)` (the last 3 protected variables) led to a clean Rchk run.