### PR TITLE
Correctly specify border.col and add.border behavior

### DIFF
--- a/R/create.polygonplot.R
+++ b/R/create.polygonplot.R
@@ -12,7 +12,7 @@
 ### FUNCTION TO CREATE POLYGONPLOT ################################################################
 create.polygonplot <- function(
 	formula, data, filename = NULL, groups = NULL, main = NULL, main.just = 'center', main.x = 0.5, main.y = 0.5,
-	main.cex = 3, max, min, col = 'white', alpha = 0.5, border.col = 'black', xy.col = 'black',
+	main.cex = 3, max, min, col = 'white', alpha = 0.5, border.col = 'black',
 	strip.col = 'white', strip.cex = 1, type = 'p', cex = 0.75, pch = 19, lwd = 1, lty = 1, axes.lwd = 1,
 	xlab.label = tail(sub('~', '', formula[-2]), 1), ylab.label = tail(sub('~', '', formula[-3]), 1),
 	xlab.cex = 2, ylab.cex = 2, xlab.col = 'black', ylab.col = 'black', xlab.top.label = NULL, xlab.top.cex = 2,
@@ -21,7 +21,7 @@ create.polygonplot <- function(
 	yaxis.log = FALSE, xaxis.fontface = 'bold', yaxis.fontface = 'bold', xaxis.col = 'black', yaxis.col = 'black',
 	xaxis.tck = 1, yaxis.tck = 1, xlimits = NULL, ylimits = NULL, xat = TRUE, yat = TRUE, layout = NULL,
 	as.table = FALSE, x.spacing = 0, y.spacing = 0, x.relation = 'same', y.relation = 'same', top.padding = 0.5,
-	bottom.padding = 2, right.padding = 1, left.padding = 2, ylab.axis.padding = 0, add.xy.border = FALSE,
+	bottom.padding = 2, right.padding = 1, left.padding = 2, ylab.axis.padding = 0, add.border = FALSE, add.xy.border = NULL,
 	add.median = FALSE, median.lty = 3, median.lwd = 1.5, use.loess.border = FALSE, use.loess.median = FALSE,
 	median = NULL, median.col = 'black', extra.points = NULL, extra.points.pch = 21, extra.points.type = 'p',
 	extra.points.col = 'black', extra.points.fill = 'white', extra.points.cex = 1, add.rectangle = FALSE,
@@ -40,7 +40,7 @@ create.polygonplot <- function(
 			dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
 			if (!dir.exists(dir.name)) {
 				dir.create(dir.name);
-				}			
+				}
 			funcname <- 'create.polygonplot';
 			print.to.file(dir.name, funcname, data, filename);
 			},
@@ -49,6 +49,11 @@ create.polygonplot <- function(
 		error = function(e) {
 			}
 		);
+
+	if (!missing(add.xy.border)) {
+		add.border <- add.xy.border;
+		warning('add.xy.border is deprecated. Use add.border instead');
+		}
 
 	### needed to copy in case using variable to define rectangles dimensions
 	rectangle.info <- list(
@@ -197,7 +202,6 @@ create.polygonplot <- function(
 		min = min,
 		median = median,
 		panel = function(x, y, col = col, border = border.col, groups = groups.new, subscripts, ...) {
-
 			# add rectangle if requested
 			# want rectangle in the background, and only plotted once
 			#  => add first, outside of grouping if/else split
@@ -211,7 +215,7 @@ create.polygonplot <- function(
 					alpha = alpha.rectangle,
 					border = NA
 					);
-		  		}
+				}
 
 			# if requested, add y=x line
 			if (add.xyline) {
@@ -240,12 +244,12 @@ create.polygonplot <- function(
 					);
 
 				# draw xy points along border of polygon
-				if (add.xy.border) {
+				if (add.border) {
 					panel.xyplot(
 						x = c(x, rev(x)),
 						y = c(max[subscripts], rev(min[subscripts])),
-						type = 'p',
-						col = xy.col
+						type = 'l',
+						col = border.col
 						);
 					}
 
@@ -346,7 +350,7 @@ create.polygonplot <- function(
 				median.lty <- if (length(median.lty) == 1) { rep(median.lty, length(subscripts)); } else {
 					as.numeric(factor(x = groups, labels = median.lty));
 				}
-				
+
 				median.lwd <- if (length(median.lwd) == 1) { rep(median.lwd, length(subscripts)); } else {
 					as.character(factor(x = groups, labels = median.lwd));
 					}
@@ -380,16 +384,20 @@ create.polygonplot <- function(
 							...
 							);
 
+						if ((length(add.border) == 1 && add.border) || add.border[group.num]) {
+							polygon.border <- border.col[subscripts];
+							} else {
+							polygon.border <- 'black';
+							}
+
 						# draw polygon borders
-						if (length(add.xy.border) == 1 || add.xy.border[group.num]) {
-							panel.xyplot(
+						panel.xyplot(
 								x = c(x, rev(x), x[1]),
 								y = c(max[subscripts], rev(min[subscripts]), max[subscripts][1]),
 								type = 'l',
-								col = border.col[subscripts],
+								col = polygon.border,
 								lwd = lwd
 								);
-							}
 
 						# draw median line
 						if (add.median & !is.null(median)) {

--- a/R/create.polygonplot.R
+++ b/R/create.polygonplot.R
@@ -343,6 +343,10 @@ create.polygonplot <- function(
 					as.character(factor(x = groups, labels = border.col));
 					}
 
+				add.border <- if (length(add.border) == 1) { rep(add.border, length(subscripts)); } else {
+					as.character(factor(x = groups, labels = add.border));
+					}
+
 				median.col <- if (length(median.col) == 1) { rep(median.col, length(subscripts)); } else {
 					as.character(factor(x = groups, labels = median.col));
 					}

--- a/man/create.polygonplot.Rd
+++ b/man/create.polygonplot.Rd
@@ -18,7 +18,6 @@ create.polygonplot(
 	col = 'white',
 	alpha = 0.5,
 	border.col = 'black',
-	xy.col = 'black',
 	strip.col = 'white',
 	strip.cex = 1,
 	type = 'p',
@@ -66,9 +65,9 @@ create.polygonplot(
 	top.padding = 0.5,
 	bottom.padding = 2,
 	right.padding = 1,
-	left.padding = 2,	
+	left.padding = 2,
 	ylab.axis.padding = 0,
-	add.xy.border = FALSE,
+	add.border = FALSE,
 	add.median = FALSE,
 	median.lty = 3,
 	median.lwd = 1.5,
@@ -117,7 +116,7 @@ create.polygonplot(
 	size.units = 'in',
 	resolution = 1600,
 	enable.warnings = FALSE,
-	description = 'Created with BoutrosLab.plotting.general', 
+	description = 'Created with BoutrosLab.plotting.general',
 	style = 'BoutrosLab',
 	preload.default = 'custom',
 	use.legacy.settings = FALSE,
@@ -139,7 +138,6 @@ create.polygonplot(
     \item{col}{Fill colour of polygon, defaults to white}
     \item{alpha}{Transparency of polygons when several are plotted, defaults to 0.5.}
     \item{border.col}{Border colour(s) of polygon(s), defaults to black}
-    \item{xy.col}{Colour of xy coordinates, defaults to black}
     \item{strip.col}{Strip background colour, defaults to \dQuote{white}}
     \item{strip.cex}{Strip title character expansion}
     \item{type}{Plot type}
@@ -174,11 +172,11 @@ create.polygonplot(
     \item{yaxis.col}{Colour of the y-axis tick labels, defaults to \dQuote{black}}
     \item{xaxis.tck}{Specifies the length of the tick marks for x-axis, defaults to 1}
     \item{yaxis.tck}{Specifies the length of the tick marks for y-axis, defaults to 1}
-    \item{xlimits}{Two-element vector giving the x-axis limits} 
-    \item{ylimits}{Two-element vector giving the y-axis limits} 
+    \item{xlimits}{Two-element vector giving the x-axis limits}
+    \item{ylimits}{Two-element vector giving the y-axis limits}
     \item{xat}{Vector listing where the x-axis labels should be drawn}
     \item{yat}{Vector listing where the y-axis labels should be drawn}
-    \item{layout}{A vector specifying the number of columns, rows (e.g., c(2,1). Default is NULL; see lattice::xyplot for more details}.  
+    \item{layout}{A vector specifying the number of columns, rows (e.g., c(2,1). Default is NULL; see lattice::xyplot for more details}.
     \item{as.table}{Specifies panel drawing order, default is FALSE which draws panels from bottom left corner, moving right then up. Set to TRUE to draw from top left corner, moving right then down}
     \item{x.spacing}{A number specifying the distance between panels along the x-axis, defaults to 0}
     \item{y.spacing}{A number specifying the distance between panels along the y-axis, defaults to 0}
@@ -188,8 +186,8 @@ create.polygonplot(
     \item{bottom.padding}{A number specifying the distance to the bottom margin, defaults to 2}
     \item{right.padding}{A number specifying the distance to the right margin, defaults to 1}
     \item{left.padding}{A number specifying the distance to the left margin, defaults to 2}
-    \item{ylab.axis.padding}{A number specifying the distance of ylabel to the y-axis, defaults to 0}, 
-    \item{add.xy.border}{Add xy border to polygon, default is FALSE}
+    \item{ylab.axis.padding}{A number specifying the distance of ylabel to the y-axis, defaults to 0},
+    \item{add.border}{Add xy border to polygon, default is FALSE}
     \item{add.median}{Add median line, default is FALSE}
     \item{median.lty}{Median line type}
     \item{median.lwd}{Median line width, defaults to 1.5}
@@ -252,7 +250,7 @@ If this function is called without capturing the return value, or specifying a f
     Error in grid.Call.graphics("L_text", as.graphicsAnnot(x$label), x$x,  )
         Invalid font type
     Calls: print ... drawDetails.text -> grid.Call.graphics -> .Call.graphics
-    }       
+    }
 }
 \seealso{\code{\link[lattice]{xyplot}}, \code{\link[lattice]{lattice}} or the Lattice book for an overview of the package.}
 \examples{
@@ -293,7 +291,7 @@ fill.matrix <- function(x, gene, data){
         gene[i, i:58] <- rep(as.numeric(data[i]), 58-i+1);
         }
     return(gene);
-    }; 
+    };
 
 gene1 <- fill.matrix(1:58, gene1, data1);
 gene1 <- t(matrix(unlist(gene1), ncol = 58, byrow = TRUE));
@@ -413,7 +411,7 @@ create.polygonplot(
     yat = seq(0, 10, 2),
     col = default.colours(1),
     # border points
-    add.xy.border = TRUE,
+    add.border = TRUE,
     description = 'Polygon created by BoutrosLab.plotting.general',
     resolution = 100
     );
@@ -616,12 +614,12 @@ create.polygonplot(
         columns = 1
         ),
 
-    # set style to Nature 
+    # set style to Nature
     style = 'Nature',
-    
+
     # demonstrating how to italicize character variables
     ylab.label = expression(paste('italicized ', italic('a'))),
-  
+
     # demonstrating how to create en-dashes
     xlab.label = expression(paste('en dashs: 1','\u2013', '10'^'\u2013', ''^3)),
 


### PR DESCRIPTION
Closes #24 

See previous BPG behavior from issue. Some of the modifications that I think makes sense since I tried to fix the bug while keeping the general idea of the behavior similar. I think it makes sense to remove the `add.xy.border`/`add.border` parameter entirely and only set the border via `border.col`.

Based on these searches on our github there shouldn't be any disruptions in how border is used:
https://github.com/search?q=org%3Auclahs-cds+add%5C.xy%5C.border+-repo%3Auclahs-cds%2FBoutrosLab+language%3AR+language%3AR&type=Code

https://github.com/search?p=2&q=org%3Auclahs-cds+create.polygonplot+border.col+-repo%3Auclahs-cds%2FBoutrosLab+language%3AR+language%3AR+-repo%3Auclahs-cds%2Fpublic-R-BoutrosLab-plotting-general&type=Code

Results from this PR

## No groups - no border (no change)

```r
library(BoutrosLab.plotting.general);
set.seed(12345);

temp  <- matrix(runif(1010), ncol = 10) + sort(runif(101));

simple.data <- data.frame(
    x = 0:100,
    max = apply(temp, 1, max),
    min = apply(temp, 1, min)
);

create.polygonplot(
    formula = NA ~ x,
    data = simple.data,
    max = simple.data$max,
    min = simple.data$min,
    xlimits = c(0,100),
    ylimits = c (0,2),
    col = default.colours(1)
);
```

![image](https://user-images.githubusercontent.com/1639487/185250409-82f72f56-039b-4d27-905f-f079f64416f0.png)

## No groups - with border (different behavior)

```r
library(BoutrosLab.plotting.general);
set.seed(12345);

temp  <- matrix(runif(1010), ncol = 10) + sort(runif(101));

simple.data <- data.frame(
    x = 0:100,
    max = apply(temp, 1, max),
    min = apply(temp, 1, min)
);

create.polygonplot(
    formula = NA ~ x,
    data = simple.data,
    max = simple.data$max,
    min = simple.data$min,
    xlimits = c(0,100),
    ylimits = c(0,2),
    col = default.colours(1),
    add.border = TRUE,
    border.col = default.colours(1)
);
```

![image](https://user-images.githubusercontent.com/1639487/185251742-e7d97b0b-1e17-45eb-8cb0-f26edb466c23.png)


## Groups - no border (different behavior)

I made the behavior of this match the no group case: Black border for each of the groups

```r
library(BoutrosLab.plotting.general);
set.seed(12345);

temp  <- matrix(runif(1010), ncol = 10) + sort(runif(101));
temp2  <- matrix(runif(1010), ncol = 10) - sort(runif(101));

simple.data <- data.frame(
    x = 0:100,
    max = apply(temp, 1, max),
    min = apply(temp, 1, min),
    group = 1
);

simple.data2 <- data.frame(
    x = 0:100,
    max = apply(temp2, 1, max),
    min = apply(temp2, 1, min),
    group = 2
);

simple.data <- rbind(simple.data, simple.data2);

create.polygonplot(
    formula = NA ~ x,
    data = simple.data,
    groups = simple.data$group,
    max = simple.data$max,
    min = simple.data$min,
    xlimits = c(0,100),
    ylimits = c (0,2),
    col = default.colours(2)
);
```

![image](https://user-images.githubusercontent.com/1639487/185251166-84e276fc-1195-42dc-8ea9-33ab8a12e1d6.png)

## Groups - border (same behavior)

The only difference is that `add.border` needs to be TRUE

```r
library(BoutrosLab.plotting.general);
set.seed(12345);

temp  <- matrix(runif(1010), ncol = 10) + sort(runif(101));
temp2  <- matrix(runif(1010), ncol = 10) - sort(runif(101));

simple.data <- data.frame(
    x = 0:100,
    max = apply(temp, 1, max),
    min = apply(temp, 1, min),
    group = 1
);

simple.data2 <- data.frame(
    x = 0:100,
    max = apply(temp2, 1, max),
    min = apply(temp2, 1, min),
    group = 2
);

simple.data <- rbind(simple.data, simple.data2);

create.polygonplot(
    formula = NA ~ x,
    data = simple.data,
    groups = simple.data$group,
    max = simple.data$max,
    min = simple.data$min,
    xlimits = c(0,100),
    ylimits = c (0,2),
    col = default.colours(2),
    add.border = TRUE,
    border.col = default.colours(2)
);
```

![image](https://user-images.githubusercontent.com/1639487/185251941-c0d5940f-b93a-4c00-b76d-945955fd3f44.png)
