### PR TITLE
Fix ylab.axis.padding parameter in create.histogram

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BoutrosLab.plotting.general
-Version: 7.0.5
+Version: 7.0.6
 Type: Package
 Title: Functions to Create Publication-Quality Plots
 Date: 2022-12-29

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,10 @@
-BoutrosLab.plotting.general 7.0.5 2023-01-05
+BoutrosLab.plotting.general 7.0.6 2023-01-05
+
+BUG
+* Fix ylab.axis.padding parameter in create.histogram
+
+--------------------------------------------------------------------------
+BoutrosLab.plotting.general 7.0.5 2023-01-03
 
 UPDATE
 * Fix typo in man/create.violinplot.Rd
@@ -7,7 +13,6 @@ UPDATE
 * Correctly sort horizontal barplot
 * Remove Makefile
 * Replaced string class comparison with is()
-* Fix ylab.axis.padding parameter in create.histogram
 
 BUG
 * Fix NEWS format

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-BoutrosLab.plotting.general 7.0.5 2023-01-03
+BoutrosLab.plotting.general 7.0.5 2023-01-05
 
 UPDATE
 * Fix typo in man/create.violinplot.Rd
@@ -7,6 +7,7 @@ UPDATE
 * Correctly sort horizontal barplot
 * Remove Makefile
 * Replaced string class comparison with is()
+* Fix ylab.axis.padding parameter in create.histogram
 
 BUG
 * Fix NEWS format

--- a/R/create.histogram.R
+++ b/R/create.histogram.R
@@ -219,7 +219,7 @@ create.histogram <- function(
 				key.left = 0.1,
 				key.ylab.padding = 0.1,
 				ylab = 1,
-				ylab.axis.padding = 1,
+				ylab.axis.padding = ylab.axis.padding,
 				axis.left = 1,
 				axis.right = 1,
 				axis.key.padding = 0.1,


### PR DESCRIPTION
# Description

Fix `create.histogram` to use `ylab.axis.padding` parameter.

### Closes #71 

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.
- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

<!-- 
Admin/maintainer: please edit the remaining sections as needed for your project repo.  
Then commit/push the changes so everyone uses this template for future PRs.

For example, if your project is a `pipeline`, then create a pipeline testing results section.

If your project is a general data analysis project, then you may want to require testing results
in each PR to help prevent creating new bugs.
-->

## Example
```r
set.seed(10)
x <- rnorm(100)
create.histogram(
    x,
    ylab.label = 'ylab',
    ylab.axis.padding = 15
    )
```

![image](https://user-images.githubusercontent.com/1639487/210918471-843aa2b3-421e-4f4e-a6ec-5b454837d985.png)
