### PR TITLE
Remove axis label with NULL in `create.boxplot`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 BoutrosLab.plotting.general 7.0.6 2023-01-05
 
+UPDATE
+* Remove axis labels with axis.lab = NULL in create.boxplot for consistent behavior with other plot types
+
 BUG
 * Fix ylab.axis.padding parameter in create.histogram
 

--- a/R/create.boxplot.R
+++ b/R/create.boxplot.R
@@ -150,14 +150,6 @@ create.boxplot <- function(
 			xaxis.lab <- out$axis.lab;
 			}
 		}
-
-	# Workaround so that setting yaxis.lab = NULL will remove the yaxis label
-	# This is a bug (?) in lattice that has an issue open here
-	# https://github.com/deepayan/lattice/issues/26
-	if (is.null(yaxis.lab)) {
-		num.yaxis.labels <- length(unique(data[[parsed.formula[1]]]))
-		yaxis.lab <- rep('', num.yaxis.labels)
-		}
 	
 	# add preloaded defaults
 	if (preload.default == 'paper') {
@@ -284,6 +276,17 @@ create.boxplot <- function(
 				y = main.y
 				)
 			),
+		# Workaround so that setting yaxis.lab = NULL will remove the yaxis label
+		# This is a bug (?) in lattice that has an issue open here
+		# https://github.com/deepayan/lattice/issues/26
+		default.scales = list(
+			x = list(
+				labels = xaxis.lab
+				),
+			y = list(
+				labels = yaxis.lab
+				)
+			),
 		xlab = BoutrosLab.plotting.general::get.defaults(
 			property = 'fontfamily',
 			use.legacy.settings = use.legacy.settings || ('Nature' == style),
@@ -326,7 +329,6 @@ create.boxplot <- function(
 				property = 'fontfamily',
 				use.legacy.settings = use.legacy.settings || ('Nature' == style),
 				add.to.list = list(
-					labels = xaxis.lab,
 					rot = xaxis.rot,
 					limits = xlimits,
 					cex = xaxis.cex,
@@ -341,7 +343,6 @@ create.boxplot <- function(
 				property = 'fontfamily',
 				use.legacy.settings = use.legacy.settings || ('Nature' == style),
 				add.to.list = list(
-					labels = yaxis.lab,
 					rot = yaxis.rot,
 					limits = ylimits,
 					cex = yaxis.cex,

--- a/R/create.boxplot.R
+++ b/R/create.boxplot.R
@@ -151,6 +151,14 @@ create.boxplot <- function(
 			}
 		}
 
+	# Workaround so that setting yaxis.lab = NULL will remove the yaxis label
+	# This is a bug (?) in lattice that has an issue open here
+	# https://github.com/deepayan/lattice/issues/26
+	if (is.null(yaxis.lab)) {
+		num.yaxis.labels <- length(unique(data[[parsed.formula[1]]]))
+		yaxis.lab <- rep('', num.yaxis.labels)
+		}
+	
 	# add preloaded defaults
 	if (preload.default == 'paper') {
 		}

--- a/R/create.boxplot.R
+++ b/R/create.boxplot.R
@@ -277,7 +277,6 @@ create.boxplot <- function(
 				)
 			),
 		# Workaround so that setting yaxis.lab = NULL will remove the yaxis label
-		# This is a bug (?) in lattice that has an issue open here
 		# https://github.com/deepayan/lattice/issues/26
 		default.scales = list(
 			x = list(

--- a/man/create.boxplot.Rd
+++ b/man/create.boxplot.Rd
@@ -163,8 +163,8 @@ create.boxplot(
     \item{ylimits}{Two-element vector giving the y-axis limits}
     \item{xat}{Vector listing where the x-axis labels should be drawn}
     \item{yat}{Vector listing where the y-axis labels should be drawn}
-    \item{xaxis.lab}{Vector listing x-axis tick labels, defaults to automatic}
-    \item{yaxis.lab}{Vector listing y-axis tick labels, defaults to automatic}
+    \item{xaxis.lab}{Vector listing x-axis tick labels, defaults to automatic (TRUE). Set to NULL to remove x-axis labels.}
+    \item{yaxis.lab}{Vector listing y-axis tick labels, defaults to automatic (TRUE). Set to NULL to remove y-axis labels.}
     \item{xaxis.cex}{Size of x-axis tick labels, defaults to 2}
     \item{yaxis.cex}{Size of y-axis tick labels, defaults to 2}
     \item{xaxis.col}{Colour of the x-axis tick labels, defaults to \dQuote{black}}

--- a/man/create.boxplot.Rd
+++ b/man/create.boxplot.Rd
@@ -364,6 +364,25 @@ create.boxplot(
     description = 'Boxplot created by BoutrosLab.plotting.general',
     resolution = 100
     );
+    
+# Remove y-axis labels
+create.boxplot(
+    formula = y ~ x,
+    data = reformatted.data,
+    main = 'Remove y-axis labels',
+    xaxis.cex = 1,
+    yaxis.cex = 1,
+    xlab.cex = 1.5,
+    ylab.cex = 1.5,
+    ylab.label = 'Gene',
+    xlimits = c(0,13),
+    xat = seq(0,12,2),
+    yaxis.lab = NULL, # Remove labels with NULL
+    # Colour change
+    col = sex.colour,
+    description = 'Boxplot created by BoutrosLab.plotting.general',
+    resolution = 100
+    );
 
 # Legend
 create.boxplot(


### PR DESCRIPTION
# Description
Make behavior of axis.lab = NULL for `create.boxplot` consistent with other functions.

### Closes #62 

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.
- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

<!-- 
Admin/maintainer: please edit the remaining sections as needed for your project repo.  
Then commit/push the changes so everyone uses this template for future PRs.

For example, if your project is a `pipeline`, then create a pipeline testing results section.

If your project is a general data analysis project, then you may want to require testing results
in each PR to help prevent creating new bugs.
-->

## Example

``` r
library(BoutrosLab.plotting.general, quietly = T, warn.conflicts = F);
set.seed(10);
simple.data <- data.frame(
    x = rnorm(100),
    y = sample(1:5, replace = T, size = 100)
    );

create.boxplot(
    formula = y ~ x,
    data = simple.data,
    yaxis.lab = NULL
    );
```

![](https://i.imgur.com/7c1kFfR.png)

``` r

create.boxplot(
    formula = y ~ x,
    data = simple.data,
    xaxis.lab = NULL
    );
```

![](https://i.imgur.com/qMbNePZ.png)

<sup>Created on 2023-01-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>