### PR TITLE
Add text ability for create.histogram

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 BoutrosLab.plotting.general 7.0.6 2023-01-05
 
+UPDATE
+* Add text support for create.histogram
+
 BUG
 * Fix ylab.axis.padding parameter in create.histogram
 

--- a/R/create.histogram.R
+++ b/R/create.histogram.R
@@ -21,6 +21,8 @@ create.histogram <- function(
 	x.relation = 'same', y.relation = 'same', strip.col = 'white', strip.cex = 1, top.padding = 0.1,
 	bottom.padding = 0.7, right.padding = 0.1, left.padding = 0.5, ylab.axis.padding = 0, abline.h = NULL,
 	abline.v = NULL, abline.col = 'black', abline.lwd = 1, abline.lty = 1, key = NULL, legend = NULL,
+	add.text = FALSE, text.labels = NULL, text.x = NULL, text.y = NULL, text.col = 'black',
+	text.cex = 1, text.fontface = 'bold',
 	add.rectangle = FALSE, xleft.rectangle = NULL, ybottom.rectangle = NULL, xright.rectangle = NULL,
 	ytop.rectangle = NULL, col.rectangle = 'transparent', alpha.rectangle = 1, height = 6, width = 6,
 	size.units = 'in', resolution = 1600, enable.warnings = FALSE,
@@ -60,6 +62,15 @@ create.histogram <- function(
 		}
 	else if (preload.default == 'web') {
 		}
+
+	text.info <- list(
+		labels = text.labels,
+		x = text.x,
+		y = text.y,
+		col = text.col,
+		cex = text.cex,
+		fontface = text.fontface
+		);
 
 	# Now make the actual plot object
 	trellis.object <- lattice::histogram(
@@ -103,7 +114,19 @@ create.histogram <- function(
 					lwd = abline.lwd,
 					col = abline.col
 					);
-				}
+			}
+			
+			# Add text to plot
+			if (add.text) {
+				panel.text(
+					x        = text.info$x,
+					y        = text.info$y,
+					labels   = text.info$labels,
+					col      = text.info$col,
+					cex      = text.info$cex,
+					fontface = text.info$fontface
+					);
+				}			
 			},
 		type = type,
 		col = col,

--- a/man/create.histogram.Rd
+++ b/man/create.histogram.Rd
@@ -65,6 +65,13 @@ create.histogram(
 	abline.lty = 1,
 	key = NULL,
 	legend = NULL,
+	add.text = FALSE,
+	text.labels = NULL,
+	text.x = NULL,
+	text.y = NULL,
+	text.col = 'black',
+	text.cex = 1,
+	text.fontface = 'bold',	
 	add.rectangle = FALSE,
 	xleft.rectangle = NULL,
 	ybottom.rectangle = NULL,
@@ -146,6 +153,13 @@ create.histogram(
     \item{abline.lty}{Specifies horizontal/vertical line style, defaults to 1 (solid)}
     \item{key}{Add a key to the plot. See xyplot.}
     \item{legend}{Add a legend to the plot.  Helpful for adding multiple keys and adding keys to the margins of the plot. See xyplot.}
+    \item{add.text}{Allow additional text to be drawn, default is FALSE}
+    \item{text.labels}{Labels for additional text}
+    \item{text.x}{The x co-ordinates where additional text should be placed}
+    \item{text.y}{The y co-ordinates where additional text should be placed}
+    \item{text.col}{The colour of additional text}
+    \item{text.cex}{The size of additional text}
+    \item{text.fontface}{The fontface for additional text}    
     \item{add.rectangle}{Allow a rectangle to be drawn, default is FALSE}
     \item{xleft.rectangle}{Specifies the left x ooordinate of the rectangle to be drawn}
     \item{ybottom.rectangle}{Specifies the bottom y coordinate of the rectangle to be drawn}


### PR DESCRIPTION
# Description
Implement `add.text` capabilities for `create.histogram`. Identical implementation to `create.barplot`

### Closes #21 

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.
- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

## Example

``` r
suppressPackageStartupMessages(library(BoutrosLab.plotting.general));
set.seed(10);
x <- rnorm(100);
create.histogram(
    x = x,
    add.text = TRUE,
    text.x = -2,
    text.y = 20,
    text.labels = 'Text'
    );
```

![](https://i.imgur.com/27CY5Q9.png)

<sup>Created on 2023-01-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>