### PR TITLE
Update citation information to match `citation('Boutros.plotting.general')`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,25 @@ For lists of contributors please visit [here](https://uclahs-cds.github.io/publi
 
 ## Citation information
 
-P’ng, C., Green, J., Chong, L.C. et al. BPG: Seamless, automated and interactive visualization of scientific data. *BMC Bioinformatics* **20**, 42 (2019). https://doi.org/10.1186/s12859-019-2610-2
+To cite package `BoutrosLab.plotting.general` in publications use:
+
+  Paul Boutros (2022). _BoutrosLab.plotting.general: Functions to
+  Create Publication-Quality Plots_. R package version 7.0.3,
+  <https://CRAN.R-project.org/package=BoutrosLab.plotting.general>.
+
+A BibTeX entry for LaTeX users is
+
+```
+  @Manual{,
+    title = {BoutrosLab.plotting.general: Functions to Create Publication-Quality Plots},
+    author = {{Paul Boutros}},
+    year = {2022},
+    note = {R package version 7.0.3},
+    url = {https://CRAN.R-project.org/package=BoutrosLab.plotting.general},
+  }
+```
+
+This information is available via `citation('BoutrosLab.plotting.general')`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -124,23 +124,25 @@ For lists of contributors please visit [here](https://uclahs-cds.github.io/publi
 
 To cite package `BoutrosLab.plotting.general` in publications use:
 
-  Paul Boutros (2022). _BoutrosLab.plotting.general: Functions to
-  Create Publication-Quality Plots_. R package version 7.0.3,
-  <https://CRAN.R-project.org/package=BoutrosLab.plotting.general>.
+P’ng, C., Green, J., Chong, L.C. et al. _BPG: Seamless, automated and interactive visualization of scientific data_. BMC Bioinformatics 20, 42 (2019). https://doi.org/10.1186/s12859-019-2610-2
 
 A BibTeX entry for LaTeX users is
 
-```
-  @Manual{,
-    title = {BoutrosLab.plotting.general: Functions to Create Publication-Quality Plots},
-    author = {{Paul Boutros}},
-    year = {2022},
-    note = {R package version 7.0.3},
-    url = {https://CRAN.R-project.org/package=BoutrosLab.plotting.general},
+```BibTeX
+  @Article{,
+    title = {BPG: Seamless, automated and interactive visualization of scientific data},
+    journal = {BMC Bioinformatics},
+    doi = {10.1186/s12859-019-2610-2},
+    url = {https://doi.org/10.1186/s12859-019-2610-2},
+    volume = {20},
+    number = {42},
+    year = {2019},
+    month = {January},
+    day = {21},
+    issn = {1471-2105},
+    author = {Christine P'ng and Jeffrey Green and Lauren C. Chong and Daryl Waggott and Stephenie D. Prokopec and Mehrdad Shamsi and Francis Nguyen and Denise Y. F. Mak and Felix Lam and Marco A. Albuquerque and Ying Wu and Esther H. Jung and Maud H. W. Starmans and Michelle A. Chan-Seng-Yue and Cindy Q. Yao and Bianca Liang and Emilie Lalonde and Syed Haider and Nicole A. Simone and Dorota Sendorek and Kenneth C. Chu and Nathalie C. Moon and Natalie S. Fox and Michal R. Grzadkowski and Nicholas J. Harding and Clement Fung and Amanda R. Murdoch and Kathleen E. Houlahan and Jianxin Wang and David R. Garcia and Richard de Borja and Ren X. Sun and Xihui Lin and Gregory M. Chen and Aileen Lu and Yu-Jia Shiah and Amin Zia and Ryan Kearns and Paul C. Boutros},
   }
 ```
-
-This information is available via `citation('BoutrosLab.plotting.general')`
 
 ## License
 


### PR DESCRIPTION
# Description
Update citation information to match `citation('Boutros.plotting.general')` to keep consistent with changes suggested to VennDiagram README

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.
- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [ ] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
