### PR TITLE
Add ability to use expressions in main title and ylab.label.right for multipanelplot

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,7 +6,7 @@ UPDATE
 
 BUG
 * Fix ylab.axis.padding parameter in create.histogram
-* Fix error when using expressions in multipanelplot labels
+* Fix error when using expressions in multipanelplot labels and main
 
 --------------------------------------------------------------------------
 BoutrosLab.plotting.general 7.0.5 2023-01-03

--- a/R/create.multipanelplot.R
+++ b/R/create.multipanelplot.R
@@ -483,7 +483,7 @@ create.multipanelplot <- function(plot.objects = NULL, filename = NULL, height =
 			);
 
     		width.text <- 0;
-		if (ylab.label.right != '') {
+		if (nchar(ylab.label.right) > 0) {
 			width.text <- convertUnit(
 				grobWidth(y.label.right),
 				unitTo = 'lines',
@@ -533,7 +533,7 @@ create.multipanelplot <- function(plot.objects = NULL, filename = NULL, height =
 	else {
 
     		width.text <- 0;
-		if (ylab.label.right != '') {
+		if (nchar(ylab.label.right) > 0) {
 			width.text <- convertUnit(
 				grobWidth(y.label.right),
 				unitTo = 'lines',

--- a/R/create.multipanelplot.R
+++ b/R/create.multipanelplot.R
@@ -689,7 +689,7 @@ create.multipanelplot <- function(plot.objects = NULL, filename = NULL, height =
 			valueOnly = TRUE
 			);
     		height.text <- 0;
-		if (main != '') {
+		if (nchar(main) > 0) {
 			height.text <- convertUnit(
 				grobHeight(main.label),
 				unitTo = 'lines',
@@ -738,7 +738,7 @@ create.multipanelplot <- function(plot.objects = NULL, filename = NULL, height =
 		}
 	else {
 		height.text <- 0;
-		if (main != '') {
+		if (nchar(main) > 0) {
 			height.text <- convertUnit(
 				grobHeight(main.label),
 				unitTo = 'lines',


### PR DESCRIPTION
## Description

Multipanelplots were not able to use expressions for `main`. This was fixed for `xlab` and `ylab` in #90 but still was an issue for main title.

### Closes #105 

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [x] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [x] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [x] Both `R CMD build` and `R CMD check` run successfully.

## Testing Results

``` r
library(BoutrosLab.plotting.general);
data <- data.frame(
    x = rnorm(50), y = rnorm(50)
    );

p1 <- create.scatterplot(
    y ~ x, data = data
    );

create.multipanelplot(
    list(p1),
    main = expression(x[2]),
    ylab.label.right = expression(x[3])
    );
```

![](https://i.imgur.com/yTYsHQj.png)

<sup>Created on 2023-03-10 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>