### PR TITLE
Remove duplicated definitions of print/plot.multipanel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BoutrosLab.plotting.general
-Version: 7.0.6
+Version: 7.0.7
 Type: Package
 Title: Functions to Create Publication-Quality Plots
 Date: 2023-02-10

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+BoutrosLab.plotting.general 7.0.7 2023-03-22
+
+UPDATE
+* Remove duplicated code in print.multipanel
+
+--------------------------------------------------------------------------
 BoutrosLab.plotting.general 7.0.6 2023-02-15
 
 UPDATE

--- a/R/create.multipanelplot.R
+++ b/R/create.multipanelplot.R
@@ -12,16 +12,7 @@ print.multipanel <- function(x, ...) {
   	grid.draw(x);
 	}
 
-plot.multipanel <- function(x, ...) {
-	## set class to that of a grid object
-	class(x) <- c('frame', 'gTree', 'grob', 'gDesc');
-	## close previous items if exist
-	if (!is.null(dev.list()) && length(unlist(grid.ls(print = FALSE))) > 0) {
-		grid.remove(grid.ls(print = FALSE)$name[1], redraw = TRUE);
-		}
-	## draw the plot like a grob
-  	grid.draw(x);
-	}
+plot.multipanel <- print.multipanel
 
 create.multipanelplot <- function(plot.objects = NULL, filename = NULL, height = 10, width = 10, resolution = 1000,
 	plot.objects.heights = c(rep(1, layout.height)), plot.objects.widths = c(rep(1, layout.width)), layout.width = 1,

--- a/R/create.multipanelplot.R
+++ b/R/create.multipanelplot.R
@@ -2,15 +2,15 @@
 ### This is needed because without it, the returned object is a grob which you must call grid.draw(x) on, this way, we can simply print the object.
 
 print.multipanel <- function(x, ...) {
-	## set class to that of a grid object
-	class(x) <- c('frame', 'gTree', 'grob', 'gDesc');
-	## close previous items if exist
-	if (!is.null(dev.list()) && length(unlist(grid.ls(print = FALSE))) > 0) {
-		grid.remove(grid.ls(print = FALSE)$name[1], redraw = TRUE);
-		}
-	## draw the plot like a grob
-  	grid.draw(x);
-	}
+    ## set class to that of a grid object
+    class(x) <- c('frame', 'gTree', 'grob', 'gDesc');
+    ## close previous items if exist
+    if (!is.null(dev.list()) && length(unlist(grid.ls(print = FALSE))) > 0) {
+        grid.remove(grid.ls(print = FALSE)$name[1], redraw = TRUE);
+        }
+    ## draw the plot like a grob
+      grid.draw(x);
+    }
 
 plot.multipanel <- print.multipanel
 


### PR DESCRIPTION
## Description

Removes copy-pasted block of code for `print.multipanel`.

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [x] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [x] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [x] Both `R CMD build` and `R CMD check` run successfully.