### PR TITLE
Fix error with expressions in main for multipanelplots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BoutrosLab.plotting.general
-Version: 7.0.6
+Version: 7.0.7
 Type: Package
 Title: Functions to Create Publication-Quality Plots
 Date: 2023-02-10

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+BoutrosLab.plotting.general 7.0.7 2023-04-21
+
+Bug
+* Fix error with expressions in main for multipanelplots
+
+--------------------------------------------------------------------------
+
 BoutrosLab.plotting.general 7.0.6 2023-02-15
 
 UPDATE

--- a/R/create.multipanelplot.R
+++ b/R/create.multipanelplot.R
@@ -315,7 +315,7 @@ create.multipanelplot <- function(plot.objects = NULL, filename = NULL, height =
 
 				plot.objects[[j]]$par.settings$layout.heights$axis.xlab.padding <- xlab.axis.padding[ceiling(i / (layout.width * 2))] + to.add;
 
-				if (max.main != 0 && (is.null(plot.objects[[j]]$main$label) || plot.objects[[j]]$main$label == '')) {
+				if (max.main != 0 && (is.null(plot.objects[[j]]$main$label) || nchar(plot.objects[[j]]$main$label) == 0)) {
 					plot.objects[[j]]$main$label <- '\t'; #make sure it thinks a label is there
 					}
 


### PR DESCRIPTION
## Description

<!--- Briefly describe the changes included in this pull request  --->

### Closes #107 

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [x] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [x] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [x] Both `R CMD build` and `R CMD check` run successfully.

## Testing Results

``` r
library(BoutrosLab.plotting.general);

plot1 <- create.scatterplot(
    mpg ~ wt,
    data = mtcars,
    main = expression(Delta)
    );

create.multipanelplot(
    plot.objects = list(plot1),
    main = expression(Gamma)
    );
```

![](https://i.imgur.com/99iqzJK.png)

<sup>Created on 2023-04-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>