### PR TITLE
Remove outdated data storage code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: BoutrosLab.plotting.general
-Version: 7.0.6
+Version: 7.0.7
 Type: Package
 Title: Functions to Create Publication-Quality Plots
-Date: 2023-02-10
+Date: 2023-05-17
 Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@mednet.ucla.edu"),
              person("Christine P'ng", role = "ctb"),
              person("Jeff Green", role = "ctb"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+BoutrosLab.plotting.general 7.0.7 2023-05-17
+
+REMOVED
+* Removed outdated plotting data storage code
+
+--------------------------------------------------------------------------
 BoutrosLab.plotting.general 7.0.6 2023-02-15
 
 UPDATE

--- a/R/create.barplot.R
+++ b/R/create.barplot.R
@@ -38,20 +38,6 @@ create.barplot <- function(
 	use.legacy.settings = FALSE, inside.legend.auto = FALSE, disable.factor.sorting = FALSE
 	) {
 
-	### store data on mount
-        tryCatch({
-			dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-                        if (!dir.exists(dir.name)) {
-                                dir.create(dir.name);
-                                }
-			funcname <- 'create.barplot';
-                        print.to.file(dir.name, funcname, data, filename);
-                        },
-                warning = function(w) {
-                        },
-                error = function(e) {
-                	});
-
 	### needed to copy in case using variable to define rectangles dimensions
 	rectangle.info <- list(
 		xright = xright.rectangle,

--- a/R/create.boxplot.R
+++ b/R/create.boxplot.R
@@ -34,51 +34,6 @@ create.boxplot <- function(
 	use.legacy.settings = FALSE, disable.factor.sorting = FALSE
 	) {
 
-	### needed to copy in case using variable to define rectangles dimensions -- wont carry through after change
-	### store data on mount
-	tryCatch({
-			dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-			if (!dir.exists(dir.name)) {
-				dir.create(dir.name);
-				}
-			funcname <- 'create.boxplot';
-			print.to.file(dir.name, funcname, data, filename);
-
-			## save all the parameters input (minus data) for later use
-			param.data.filename <- paste(dir.name, 'data.RData', sep = '/Boxplot-');
-			data.list.boxplot <- list();
-			if (file.exists(param.data.filename)) {
-				load(param.data.filename);
-				}
-			data.list.boxplot[[length(data.list.boxplot) + 1]] <- list(
-				formula = formula, filename = filename, main = main, main.just = main.just, main.x = main.x, main.y = main.y, main.cex = main.cex,
-				add.stripplot = add.stripplot, jitter.factor = jitter.factor, jitter.amount = jitter.amount, points.pch = points.pch,
-				points.col = points.col, points.cex = points.cex, points.alpha = points.alpha, abline.h = abline.h, abline.v = abline.v,
-				adline.lty = abline.lty, abline.lwd = abline.lwd, abline.col = abline.col, add.rectangle = add.rectangle,
-				xleft.rectangle = xleft.rectangle, ybottom.rectangle = ybottom.rectangle, xright.rectangle = xright.rectangle,
-				ytop.rectangle = ytop.rectangle, col.rectangle = col.rectangle, alpha.rectangle = alpha.rectangle, box.ratio = box.ratio, col = col,
-				border.col = border.col, symbol.cex = symbol.cex, lwd = lwd, outliers = outliers, sample.order = sample.order, order.by = order.by,
-				xlab.label = xlab.label, ylab.label = ylab.label, xlab.cex = xlab.cex, ylab.cex = ylab.cex, xlab.col = xlab.col, ylab.col = ylab.col,
-				xlab.top.label = xlab.top.label, xlab.top.cex = xlab.top.cex, xlab.top.col = xlab.top.col, xlab.top.just = xlab.top.just,
-				xlab.top.just = xlab.top.just, xlab.top.x = xlab.top.x, xlab.top.y = xlab.top.y, xlimits = xlimits, ylimits = ylimits, xat = xat,
-				yat = yat, xaxis.lab = xaxis.lab, yaxis.lab = yaxis.lab, xaxis.cex = xaxis.cex, xaxis.col = xaxis.col, yaxis.col = yaxis.col,
-				xaxis.fontface = xaxis.fontface, yaxis.fontface = yaxis.fontface, xaxis.rot = xaxis.rot, yaxis.rot = yaxis.rot, xaxis.tck = xaxis.tck,
-				yaxis.tck = yaxis.tck, layout = layout, as.table = as.table, x.spacing = x.spacing, y.spacing = y.spacing, x.relation = x.relation,
-				y.relation = y.relation, top.padding = top.padding, bottom.padding = bottom.padding, right.padding = right.padding,
-				left.padding = left.padding, ylab.axis.padding = ylab.axis.padding, add.text = add.text, text.labels = text.labels, text.x = text.x,
-				text.y = text.y, text.anchor = text.anchor, text.col = text.col, text.cex = text.cex, text.fontface = text.fontface, key = key,
-				legend = legend, strip.col = strip.col, strip.cex = strip.cex, strip.fontface = strip.fontface, line.func = line.func,
-				line.from = line.from, line.to = line.to, line.col = line.col, line.infront = line.infront, height = height, width = width,
-				size.units = size.units, resolution = resolution
-				);
-			save(data.list.boxplot, file = param.data.filename);
-			},
-		warning = function(w) {
-			},
-		error = function(e) {
-			}
-		);
-
     parsed.formula <- unlist(strsplit(deparse(formula), ' [~|] '));
     formula.is.split <- '|' %in% all.names(formula);
 

--- a/R/create.densityplot.R
+++ b/R/create.densityplot.R
@@ -27,20 +27,6 @@ create.densityplot <- function(
 	description = 'Created with BoutrosLab.plotting.general', style = 'BoutrosLab', preload.default = 'custom', use.legacy.settings = FALSE,
 	inside.legend.auto = FALSE
 	) {
-	
-	### store data on mount
-        tryCatch({
-                        dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-			if( !dir.exists(dir.name) ) {
-                                dir.create(dir.name);
-                                }                        
-			funcname <- 'create.densityplot';
-                        print.to.file(dir.name, funcname, x, filename);
-                        },
-                warning = function(w) {
-                        },
-                error = function(e) {
-                	})
 
 	### needed to copy in case using variable to define rectangles dimensions
 	rectangle.info <- list(

--- a/R/create.dotmap.R
+++ b/R/create.dotmap.R
@@ -29,20 +29,6 @@ create.dotmap <- function(x, bg.data = NULL, filename = NULL, main = NULL, main.
 	alpha.rectangle = 1, xaxis.fontface = 'bold', yaxis.fontface = 'bold', dot.colour.scheme = NULL,
 	style = 'BoutrosLab', preload.default = 'custom', use.legacy.settings = FALSE, remove.symmetric = FALSE, lwd = 2) {
 
-	### store data on mount
-        tryCatch({
-                        dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-			if( !dir.exists(dir.name) ) {
-                                dir.create(dir.name);
-                                }                        
-			funcname <- 'create.dotmap';
-                        print.to.file(dir.name, funcname, x, filename);
-                        },
-                warning = function(w) {
-                        },
-                error = function(e) {
-                	});
-
 	### needed to copy in case using variable to define rectangles dimensions
 	rectangle.info <- list(
 		xright = xright.rectangle,

--- a/R/create.heatmap.R
+++ b/R/create.heatmap.R
@@ -40,69 +40,8 @@ create.heatmap <- function(x, filename = NULL, clustering.method = 'diana', clus
 	yaxis.covariates.x = NULL, description = 'Created with BoutrosLab.plotting.general', xaxis.fontface = 'bold',
 	yaxis.fontface = 'bold', symbols = list(borders = NULL, squares = NULL, circles = NULL), same.as.matrix = FALSE,
 	input.colours = FALSE, axis.xlab.padding = 0.1, stratified.clusters.rows = NULL, stratified.clusters.cols = NULL,
-	inside.legend = NULL, style = 'BoutrosLab', preload.default = 'custom', use.legacy.settings = FALSE) {
-
-	### store data on mount
-	tryCatch({
-		dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-		if (!dir.exists(dir.name)) {
-			dir.create(dir.name);
-			}
-		funcname <- 'create.heatmap';
-		print.to.file(dir.name, funcname, x, filename);
-			
-		## save all the parameters input (minus data) for later use
-		param.data.filename <- paste(dir.name, "data.RData", sep = "/Heatmap-");
-		data.list.heatmap <- list();
-		if (file.exists(param.data.filename)) {
-			load(param.data.filename);
-			}
-		data.list.heatmap[[length(data.list.heatmap) + 1]] <- list(filename = filename, clustering.method = clustering.method,
-			cluster.dimensions = cluster.dimensions, row.dendrogram = row.dendrogram, col.dendrogram = col.dendrogram,
-			plot.dendrograms = plot.dendrograms, force.clustering = force.clustering, criteria.list = criteria.list,
-			covariates = covariates, covariates.grid.row = covariates.grid.row, covariates.grid.col = covariates.grid.col,
-			covariates.grid.border = covariates.grid.border, covariates.row.lines = covariates.row.lines,
-			covariates.col.lines = covariates.col.lines, covariates.reorder.grid.index = covariates.reorder.grid.index,
-			covariates.padding = covariates.padding, covariates.top = covariates.top,
-			covariates.top.grid.row = covariates.top.grid.row, covariates.top.grid.col = covariates.top.grid.col,
-			covariates.top.grid.border = covariates.top.grid.border, covariates.top.row.lines = covariates.top.row.lines,
-			covariates.top.col.lines = covariates.top.col.lines, covariates.top.reorder.grid.index = covariates.top.reorder.grid.index,
-			covariates.top.padding = covariates.top.padding, covariate.legends = covariate.legends, legend.cex = legend.cex,
-			legend.title.cex = legend.title.cex, legend.title.just = legend.title.just, legend.title.fontface = legend.title.fontface,
-			legend.border = legend.border, legend.border.padding = legend.border.padding, legend.layout = legend.layout,
-			legend.between.col = legend.between.col, legend.between.row = legend.between.row, legend.side = legend.side,
-			main = main, main.just = main.just, main.x = main.x, main.y = main.y, main.cex = main.cex,
-			right.size.add = right.size.add, top.size.add = top.size.add, right.dendrogram.size = right.dendrogram.size,
-			top.dendrogram.size = top.dendrogram.size, scale.data = scale.data, yaxis.lab = yaxis.lab,
-			xaxis.lab = xaxis.lab, xaxis.lab.top = xaxis.lab.top, xaxis.cex = xaxis.cex, xaxis.top.cex = xaxis.top.cex,
-			yaxis.cex = yaxis.cex, xlab.cex = xlab.cex, ylab.cex = ylab.cex, xlab.top.label = xlab.top.label,
-			xlab.top.cex = xlab.top.cex, xlab.top.col = xlab.top.col, xlab.top.just = xlab.top.just,
-			xlab.top.x = xlab.top.x, xlab.top.y = xlab.top.y, xat = xat, xat.top = xat.top, yat = yat, xaxis.tck = xaxis.tck,
-			xaxis.top.tck = xaxis.top.tck, yaxis.tck = yaxis.tck, xaxis.col = xaxis.col, yaxis.col = yaxis.col,
-			col.pos = col.pos, row.pos = row.pos, cell.text = cell.text, text.fontface = text.fontface, text.cex = text.cex,
-			text.col = text.col, text.position = text.position, text.offset = text.offset,
-			text.use.grid.coordinates = text.use.grid.coordinates, colourkey.cex = colourkey.cex, xaxis.rot = xaxis.rot,
-			xaxis.rot.top = xaxis.rot.top, yaxis.rot = yaxis.rot, xlab.label = xlab.label, ylab.label = ylab.label,
-			xlab.col = xlab.col, ylab.col = ylab.col, axes.lwd = axes.lwd, gridline.order = gridline.order,
-			grid.row = grid.row, grid.col = grid.col, force.grid.row = force.grid.row, force.grid.col = force.grid.col,
-			grid.limit = grid.limit, row.lines = row.lines, col.lines = col.lines, colour.scheme = colour.scheme,
-			total.colours = total.colours, colour.centering.value = colour.centering.value, colour.alpha = colour.alpha,
-			fill.colour = fill.colour, at = at, print.colour.key = print.colour.key,
-			colourkey.labels.at = colourkey.labels.at, colourkey.labels = colourkey.labels, top.padding = top.padding,
-			bottom.padding = bottom.padding, right.padding = right.padding, left.padding = left.padding,
-			x.alternating = x.alternating, shrink = shrink, row.colour = row.colour, col.colour = col.colour,
-			row.lwd = row.lwd, col.lwd = col.lwd, grid.colour = grid.colour, grid.lwd = grid.lwd, width = width,
-			height = height, size.units = size.units, resolution = resolution, xaxis.covariates = xaxis.covariates,
-			xaxis.covariates.y = xaxis.covariates.y, yaxis.covariates = yaxis.covariates, yaxis.covariates.x = yaxis.covariates.x,
-			xaxis.fontface = xaxis.fontface, yaxis.fontface = yaxis.fontface, symbols = symbols, same.as.matrix = same.as.matrix,
-			input.colours = input.colours, axis.xlab.padding = axis.xlab.padding); 
-			save(data.list.heatmap, file = param.data.filename);
-			},
-		warning = function(w) {
-			},
-		error = function(e) {
-			}
-		);
+	inside.legend = NULL, style = 'BoutrosLab', preload.default = 'custom', use.legacy.settings = FALSE
+    ) {
 
 	### PARAMETER CHECKING #########################################################################
 	if (preload.default == 'paper') {

--- a/R/create.hexbinplot.R
+++ b/R/create.hexbinplot.R
@@ -47,20 +47,6 @@ create.hexbinplot <- function(
 	# - if 'maxcnt' is passed, make sure it is not smaller than the actual maximum count (value depends on nbins).
 	# - Otherwise, some data may be lost. If you aren't sure what the actual max count is, run this function without
 	# - specifying the 'maxcnt' parameter using the desired number of bins.
-	### store data on mount
-	tryCatch({
-			dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-			if ( !dir.exists(dir.name) ) {
-				dir.create(dir.name);
-				}			
-			funcname <- 'create.hexbinplot';
-			print.to.file(dir.name, funcname, data, filename);
-			},
-		warning = function(w) {
-			},
-		error = function(e) {
-			}
-		);
 
 	### needed to copy in case using variable to define rectangles dimensions
 	rectangle.info <- list(

--- a/R/create.histogram.R
+++ b/R/create.histogram.R
@@ -28,27 +28,13 @@ create.histogram <- function(
 	use.legacy.settings = FALSE, inside.legend.auto = FALSE
 	) {
 
-	### store data on mount
-        tryCatch({
-                        dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-			if( !dir.exists(dir.name) ) {
-                                dir.create(dir.name);
-                                }                        
-			funcname <- 'create.histogram';
-                        print.to.file(dir.name, funcname, x, filename);
-                        },
-                warning = function(w) {
-                        },
-                error = function(e) {
-                	});
-
-        ### needed to copy in case using variable to define rectangles dimensions
-        rectangle.info <- list(
-        	xright = xright.rectangle,
-                xleft = xleft.rectangle,
-                ytop = ytop.rectangle,
-                ybottom = ybottom.rectangle
-                );
+    ### needed to copy in case using variable to define rectangles dimensions
+    rectangle.info <- list(
+    	xright = xright.rectangle,
+            xleft = xleft.rectangle,
+            ytop = ytop.rectangle,
+            ybottom = ybottom.rectangle
+            );
 
 	# 'data' parameter shoud only be set if x if a formula
 	# otherwise a warning will be thrown (even if data = NULL), although the plot will still be created

--- a/R/create.manhattanplot.R
+++ b/R/create.manhattanplot.R
@@ -32,21 +32,6 @@ create.manhattanplot <- function(
 	inside.legend.auto = FALSE, ...
 	) {
 
-	### store data on mount
-        tryCatch({
-                        dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-			if( !dir.exists(dir.name) ) {
-                                dir.create(dir.name);
-                                }
-
-			funcname <- 'create.manhattanplot';
-                        print.to.file(dir.name, funcname, data, filename);
-                        },
-                warning = function(w) {
-                        },
-                error = function(e) {
-                	});
-
 	### needed to copy in case using variable to define rectangles dimensions
         rectangle.info <- list(
                 xright = xright.rectangle,

--- a/R/create.polygonplot.R
+++ b/R/create.polygonplot.R
@@ -35,21 +35,6 @@ create.polygonplot <- function(
 	use.legacy.settings = FALSE, inside.legend.auto = FALSE
 	) {
 
-	### store data on mount
-	tryCatch({
-			dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-			if (!dir.exists(dir.name)) {
-				dir.create(dir.name);
-				}
-			funcname <- 'create.polygonplot';
-			print.to.file(dir.name, funcname, data, filename);
-			},
-		warning = function(w) {
-			},
-		error = function(e) {
-			}
-		);
-
 	if (!missing(add.xy.border)) {
 		add.border <- add.xy.border;
 		warning('add.xy.border is deprecated. Use add.border instead');

--- a/R/create.qqplot.comparison.R
+++ b/R/create.qqplot.comparison.R
@@ -27,25 +27,6 @@ create.qqplot.comparison <- function(
 	description = 'Created with BoutrosLab.plotting.general', style = 'BoutrosLab', preload.default = 'custom',
 	use.legacy.settings = FALSE, inside.legend.auto = FALSE
 	) {
-	
-	### store data on mount
-        tryCatch({
-                        dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-			if( !dir.exists(dir.name) ) {
-                                dir.create(dir.name);
-                                }                        
-			funcname <- 'create.qqplot.comparison';
-			if(is.null(data)) {
-                        	print.to.file(dir.name, funcname, x, filename);
-				}
-			else {
-				print.to.file(dir.name, funcname, data, filename);
-				}
-                        },
-                warning = function(w) {
-                        },
-                error = function(e) {
-                	});
 
 	### needed to copy in case using variable to define rectangles dimensions
         rectangle.info <- list(

--- a/R/create.qqplot.fit.R
+++ b/R/create.qqplot.fit.R
@@ -28,26 +28,6 @@ create.qqplot.fit <- function(
 	style = 'BoutrosLab', preload.default = 'custom', use.legacy.settings = FALSE, inside.legend.auto = FALSE
 	) {
 
-	### store data on mount
-        tryCatch({
-                        dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-			if( !dir.exists(dir.name) ) {
-                                dir.create(dir.name);
-                                }                        
-			funcname <- 'create.qqplot.fit';
-                        if(is.null(data)) {
-                                print.to.file(dir.name, funcname, x, filename);
-                                }
-                        else {
-                                print.to.file(dir.name, funcname, data, filename);
-                                }
-
-			},
-                warning = function(w) {
-                        },
-                error = function(e) {
-                	});
-
 	### needed to copy in case using variable to define rectangles dimensions
         rectangle.info <- list(
         	xright = xright.rectangle,

--- a/R/create.scatterplot.R
+++ b/R/create.scatterplot.R
@@ -200,21 +200,6 @@ create.lollipopplot <- create.scatterplot <- function(
 	regions.alpha = 1, lollipop.bar.y = NULL, lollipop.bar.color = 'gray',  ...
 	) {
 
-	### store data on mount
-	tryCatch({
-			dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-			if ( !dir.exists(dir.name) ) {
-				dir.create(dir.name);
-				}			
-			funcname <- 'create.scatterplot';
-			print.to.file(dir.name, funcname, data, filename);
-			},
-		warning = function(w) {
-			},
-		error = function(e) {
-			}
-		);
-
 	function.name <- match.call()[[1]];
 
 	lollipop.plot <- FALSE;

--- a/R/create.segplot.R
+++ b/R/create.segplot.R
@@ -30,20 +30,6 @@ create.segplot <- function(
         disable.factor.sorting = FALSE 
 	) {
 
-        ### store data on mount
-        tryCatch({
-                        dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-			if ( !dir.exists(dir.name) ) {
-                                dir.create(dir.name);
-                                }                        
-			funcname <- 'create.segplot';
-                        print.to.file(dir.name, funcname, data, filename);
-                        },
-                warning = function(w) {
-                        },
-                error = function(e) {
-                	});
-
 	### needed to copy in case using variable to define rectangles dimensions
         rectangle.info <- list(
         	xright = xright.rectangle,

--- a/R/create.stripplot.R
+++ b/R/create.stripplot.R
@@ -30,20 +30,6 @@ create.stripplot <- function(
         disable.factor.sorting = FALSE 
 	) {
 
-	### store data on mount
-        tryCatch({
-                        dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-			if (!dir.exists(dir.name)) {
-                                dir.create(dir.name);
-                                }                        
-			funcname <- 'create.stripplot';
-                        print.to.file(dir.name, funcname, data, filename);
-                        },
-                warning = function(w) {
-                        },
-                error = function(e) {
-                	});
-
 	### needed to copy in case using variable to define rectangles dimensions
         rectangle.info <- list(
         	xright = xright.rectangle,

--- a/R/create.violinplot.R
+++ b/R/create.violinplot.R
@@ -26,23 +26,7 @@ create.violinplot <- function(
 	col.rectangle = 'transparent', alpha.rectangle = 1, height = 6, width = 6, resolution = 1600,
 	size.units = 'in', enable.warnings = FALSE, description = 'Created with BoutrosLab.plotting.general',
 	style = 'BoutrosLab', preload.default = 'custom', use.legacy.settings = FALSE, disable.factor.sorting = FALSE
-	) {
-
-
-	### store data on mount
-        tryCatch({
-                        dir.name <- '/.mounts/labs/boutroslab/private/BPGRecords/Objects';
-			if (!dir.exists(dir.name)) {
-                                dir.create(dir.name);
-                                }                        
-			funcname <- 'create.violinplot';
-                        print.to.file(dir.name, funcname, data, filename);
-                        },
-                warning = function(w) {
-                        },
-                error = function(e) {
-                	});
-
+    ) {
 
 	### needed to copy in case using variable to define rectangles dimensions
         rectangle.info <- list(


### PR DESCRIPTION
## Description


## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [X] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [X] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [ ] Both `R CMD build` and `R CMD check` run successfully.