### PR TITLE
Fix bug with continuous legends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: BoutrosLab.plotting.general
 Version: 7.0.7
 Type: Package
 Title: Functions to Create Publication-Quality Plots
-Date: 2023-05-19
+Date: 2023-05-22
 Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@mednet.ucla.edu"),
              person("Christine P'ng", role = "ctb"),
              person("Jeff Green", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: BoutrosLab.plotting.general
-Version: 7.0.6
+Version: 7.0.7
 Type: Package
 Title: Functions to Create Publication-Quality Plots
-Date: 2023-02-10
+Date: 2023-05-19
 Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@mednet.ucla.edu"),
              person("Christine P'ng", role = "ctb"),
              person("Jeff Green", role = "ctb"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+BoutrosLab.plotting.general 7.0.7 2023-05-19
+
+BUG
+* Add default label locations for continuous legends
+
+--------------------------------------------------------------------------
 BoutrosLab.plotting.general 7.0.6 2023-02-15
 
 UPDATE

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-BoutrosLab.plotting.general 7.0.7 2023-05-19
+BoutrosLab.plotting.general 7.0.7 2023-05-22
 
 BUG
 * Add default label locations for continuous legends

--- a/R/legend.grob.R
+++ b/R/legend.grob.R
@@ -143,16 +143,16 @@ legend.grob <- function(
 
 				colorRamp <- colorRampPalette(legendi[['colours']]);
 				
-				labels.at <- if (is.null(legendi[['labels']])) legendi[['at']] else {
-				    n.labels <- length(legendi[['labels']]);
-				    max.value <- if (!is.null(legendi[['continuous.amount']])) legendi[['continuous.amount']] else 100;
-			        boundaries <- seq(0, max.value, length.out = n.labels + 1);
+                labels.at <- if (is.null(legendi[['labels']])) legendi[['at']] else {
+                    n.labels <- length(legendi[['labels']]);
+                    max.value <- if (!is.null(legendi[['continuous.amount']])) legendi[['continuous.amount']] else 100;
+                    boundaries <- seq(0, max.value, length.out = n.labels + 1);
 
 			        sapply(
-			            1:(length(boundaries) - 1),
-			            FUN = function(i) boundaries[i] + (boundaries[i + 1] - boundaries[i]) / 2
-			            );
-				    }
+                        1:(length(boundaries) - 1),
+                        FUN = function(i) boundaries[i] + (boundaries[i + 1] - boundaries[i]) / 2
+                        );
+                    }
 
 				legend.key <- list(
 					space = if (!is.null(legendi[['angle']]) && legendi[['angle']] != 0) { 'bottom' } else { 'right' },

--- a/R/legend.grob.R
+++ b/R/legend.grob.R
@@ -150,7 +150,7 @@ legend.grob <- function(
                     max.value <- if (!is.null(legendi[['continuous.amount']])) legendi[['continuous.amount']] else 100;
                     boundaries <- seq(0, max.value, length.out = n.labels + 1);
 
-			        sapply(
+                    sapply(
                         1:(length(boundaries) - 1),
                         FUN = function(i) boundaries[i] + (boundaries[i + 1] - boundaries[i]) / 2
                         );

--- a/R/legend.grob.R
+++ b/R/legend.grob.R
@@ -142,15 +142,16 @@ legend.grob <- function(
 				legendi[['width']]  <- if (is.null(legendi[['width']])) { 2 } else { legendi[['width']] };
 
 				colorRamp <- colorRampPalette(legendi[['colours']]);
-				
-                labels.at <- if (is.null(legendi[['labels']])) legendi[['at']] else {
+		
+                labels.at <- legendi[['at']];
+                if (!is.null(legendi[['labels']]) && (is.null(labels.at))) {
                     n.labels <- length(legendi[['labels']]);
         
                     # Uses 0-100% as a default range
                     max.value <- if (!is.null(legendi[['continuous.amount']])) legendi[['continuous.amount']] else 100;
                     boundaries <- seq(0, max.value, length.out = n.labels + 1);
 
-                    sapply(
+                    labels.at <- sapply(
                         1:(length(boundaries) - 1),
                         FUN = function(i) boundaries[i] + (boundaries[i + 1] - boundaries[i]) / 2
                         );

--- a/R/legend.grob.R
+++ b/R/legend.grob.R
@@ -145,6 +145,8 @@ legend.grob <- function(
 				
                 labels.at <- if (is.null(legendi[['labels']])) legendi[['at']] else {
                     n.labels <- length(legendi[['labels']]);
+        
+                    # Uses 0-100% as a default range
                     max.value <- if (!is.null(legendi[['continuous.amount']])) legendi[['continuous.amount']] else 100;
                     boundaries <- seq(0, max.value, length.out = n.labels + 1);
 

--- a/R/legend.grob.R
+++ b/R/legend.grob.R
@@ -142,6 +142,18 @@ legend.grob <- function(
 				legendi[['width']]  <- if (is.null(legendi[['width']])) { 2 } else { legendi[['width']] };
 
 				colorRamp <- colorRampPalette(legendi[['colours']]);
+				
+				labels.at <- if (is.null(legendi[['labels']])) legendi[['at']] else {
+				    n.labels <- length(legendi[['labels']]);
+				    max.value <- if (!is.null(legendi[['continuous.amount']])) legendi[['continuous.amount']] else 100;
+			        boundaries <- seq(0, max.value, length.out = n.labels + 1);
+
+			        sapply(
+			            1:(length(boundaries) - 1),
+			            FUN = function(i) boundaries[i] + (boundaries[i + 1] - boundaries[i]) / 2
+			            );
+				    }
+
 				legend.key <- list(
 					space = if (!is.null(legendi[['angle']]) && legendi[['angle']] != 0) { 'bottom' } else { 'right' },
 					between = 0.5,
@@ -154,7 +166,7 @@ legend.grob <- function(
 					width = if (!is.null(legendi[['angle']]) && legendi[['angle']] != 0) { legendi[['height']] } else { legendi[['width']] },
 					labels = list(
 						labels = if (is.null(legendi[['labels']])) { c('') } else { legendi[['labels']] },
-						at     = if (is.null(legendi[['at']])) { NULL } else { legendi[['at']] },
+						at     = labels.at,
 						cex    = if (is.null(legendi[['cex']])) { 0.8 } else { legendi[['cex']] },
 						rot    = if (is.null(legendi[['labels.rot']])) { 0 } else { legendi[['labels.rot']] }
 						)


### PR DESCRIPTION
## Description

In new versions of R (> R v4.3.0), lattice does not allow `labels` to be specified in a `draw.colorkey` without corresponding values for `at`. This change fixes BPG's call to `draw.colorkey` within  `legend.grob`, placing labels equidistant along the range of continuous values.

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [X] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [X] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [X] Both `R CMD build` and `R CMD check` run successfully.