### PR TITLE
Update CRAN links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: BoutrosLab.plotting.general
 Version: 7.0.7
 Type: Package
 Title: Functions to Create Publication-Quality Plots
-Date: 2023-05-22
+Date: 2023-05-25
 Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@mednet.ucla.edu"),
              person("Christine P'ng", role = "ctb"),
              person("Jeff Green", role = "ctb"),

--- a/NEWS
+++ b/NEWS
@@ -1,8 +1,9 @@
-BoutrosLab.plotting.general 7.0.7 2023-05-22
+BoutrosLab.plotting.general 7.0.7 2023-05-25
 
 UPDATE
 * Expose panel.text arguments for text.above.bar options in create.barplot
 * Remove duplicated code in print.multipanel
+* Update format of CRAN links
 
 BUG
 * Add default label locations for continuous legends

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ For further details on usage, parameters or to see an example of a specific func
 
 ## Resources
 
-Available resources on BPG usage can be found at the package [CRAN page](https://cloud.r-project.org/web/packages/BoutrosLab.plotting.general/index.html), [reference manual](https://cloud.r-project.org/web/packages/BoutrosLab.plotting.general/BoutrosLab.plotting.general.pdf), or [vignette](https://cloud.r-project.org/web/packages/BoutrosLab.plotting.general/vignettes/PlottingGuide.pdf).
+Available resources on BPG usage can be found at the package [CRAN page](https://cran.r-project.org/package=BoutrosLab.plotting.general/index.html), [reference manual](https://cran.r-project.org/package=BoutrosLab.plotting.general/BoutrosLab.plotting.general.pdf), or [vignette](https://cran.r-project.org/package=BoutrosLab.plotting.general/vignettes/PlottingGuide.pdf).
 
 ## Getting help
 


### PR DESCRIPTION
## Description
Updates CRAN link format in `README.md`, which was creating a `NOTE` in CRAN checks.

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [X] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [X] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [X] Both `R CMD build` and `R CMD check` run successfully.
