### PR TITLE
print.to.file naming conflict

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: BoutrosLab.plotting.general
-Version: 7.0.7
+Version: 7.0.8
 Type: Package
 Title: Functions to Create Publication-Quality Plots
-Date: 2023-05-25
+Date: 2023-05-26
 Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@mednet.ucla.edu"),
              person("Christine P'ng", role = "ctb"),
              person("Jeff Green", role = "ctb"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+BoutrosLab.plotting.general 7.0.8 2023-05-26
+
+UPDATE
+* Change name of print.to.file() to export.to.file() to avoid naming conflict
+  with S3 method print()
+
+--------------------------------------------------------------------------
 BoutrosLab.plotting.general 7.0.7 2023-05-25
 
 UPDATE

--- a/R/export.to.file.R
+++ b/R/export.to.file.R
@@ -1,4 +1,4 @@
-print.to.file <- function(dirname, funcname, data, filename) {
+export.to.file <- function(dirname, funcname, data, filename) {
 
         user <- system('whoami', intern = T);
         out.filename <- 'data-df.tsv';


### PR DESCRIPTION
## Description
Similar to #16, these changes rename `print.to.file` to `export.to.file`. This is an issue with our mixed-dotted case naming convention, where function names can be misinterpreted as an S3 method for a nonexistant class (in this case, the `print` method for the class `to.file`). This results in the following error in CRAN's checks.
> ```
> Mismatches for apparent methods not registered:
>print: function(x, ...)
>print.to.file: function(dirname, funcname, data, filename)
> ```

Note, I only considered this a patch (not a breaking change) because this is a private function not exported by the package.

<!--- Briefly describe the changes included in this pull request  --->

### Closes #... <!-- edit if this PR closes an Issue -->

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [ ] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [ ] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [ ] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [ ] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [ ] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [ ] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [ ] Both `R CMD build` and `R CMD check` run successfully.

## Testing Results

<!-- Include a small working example and a screenshot of the results if applicable. You can use the `reprex` package to automatically generate example code -->

### Case 1

``` r
# input code
```

### Case 2

``` r
# input code
```
