### PR TITLE
Bump R-CMD-check-action to v2

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,4 +33,4 @@ jobs:
             libjpeg-dev \
             libpng-dev \
             libcairo2-dev
-      - uses: uclahs-cds/tool-R-CMD-check-action@renv
+      - uses: uclahs-cds/tool-R-CMD-check-action@v2


### PR DESCRIPTION
This PR updates the `R CMD check` action to its newest `v2` release.
