### PR TITLE
Revert #210

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,7 +32,5 @@ jobs:
           sudo apt-get install -y \
             libjpeg-dev \
             libpng-dev \
-            libcairo2-dev \
-            libv8-dev \
-            libcurl4-openssl-dev
+            libcairo2-dev
       - uses: uclahs-cds/tool-R-CMD-check-action@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,8 +27,7 @@ Imports: gridExtra, tools, methods, gtable, e1071, MASS(>= 7.3-29)
 Suggests:
     Cairo (>= 1.5-1),
     knitr,
-    testthat (>= 3.0.0),
-    V8
+    testthat (>= 3.0.0)
 Description: Contains several plotting functions such as barplots, scatterplots, heatmaps, as well as functions to combine plots and assist in the creation of these plots. These functions will give users great ease of use and customization options in broad use for biomedical applications, as well as general purpose plotting. Each of the functions also provides valid default settings to make plotting data more efficient and producing high quality plots with standard colour schemes simpler. All functions within this package are capable of producing plots that are of the quality to be presented in scientific publications and journals. P'ng et al.; BPG: Seamless, automated and interactive visualization of scientific data; BMC Bioinformatics 2019 <doi:10.1186/s12859-019-2610-2>.
 License: GPL-2
 URL: https://github.com/uclahs-cds/package-BoutrosLab-plotting-general


### PR DESCRIPTION
I'm proposing revert #210 to remove the V8 dependency since it has created additional issues #215 that block us from fixing #205 and #209.

@dan-knight  said the V8 note in our github action is a false positive and has not been flagged by CRAN before, so it seems V8 is unnecessary and we can remove it for now.

> * checking HTML version of manual ... NOTE
Skipping checking math rendering: package 'V8' unavailable

Closes #215